### PR TITLE
[chore] tsconfig baseUrl, paths 설정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@pages/*": ["../pages/*"],
+      "@shared/*": ["shared/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 🚀 Chore: tsconfig.json baseUrl, path 세팅

- 대부분의 import / export는 src에서 일어날 것이기 때문에 baseUrl은 src로 설정했습니다.
- 정확히 어떤 폴더에서 나온 것인지를 파악하기 위해 shared 이후 디테일은 설정하지 않았습니다.

## ✅ 유의사항

- 만약, shared/components/Button.tsx를 import한다고 가정하면 Button의 출처를 위해
import from shared/components가 되도록 shared/* 로 설정했습니다.

- shared/[pageName]/components/[componentName]의 경우 import from [pageName]/[componentName]이 되도록 **paths에 
"@[pageName]/\*": "[pageName]/\*"** 를 추가해 주시면 됩니다.

- 단, shared/plan/enroll/components/EnrollMyPlan.tsx 를 import한다고 가정하면 EnrollMyPlan의 출처를 위해
import from enroll/components가 되도록 **paths에 "@enroll/\*": "plan/enroll/\*"** 를 추가해 주시면 됩니다.

- 요점은 pages 폴더에 있는 각 페이지의 네이밍과 shared/[pageName]/..../components에서
components 바로 밑에 있는 폴더의 네이밍을 맞추는 것입니다.