### PR TITLE
Feat: useAuthTimer hook 추가

### DIFF
--- a/src/shared/components/AuthTimer.tsx
+++ b/src/shared/components/AuthTimer.tsx
@@ -1,29 +1,7 @@
-import { useEffect, useState } from "react";
-import { clearInterval, setInterval } from "timers";
-
-const AuthTimer = () => {
-  const MINUTES_IN_MS = 3 * 60 * 1000;
-  const INTERVAL = 1000;
-  const [timeLeft, setTimeLeft] = useState(MINUTES_IN_MS);
-  const minutes = String(Math.floor((timeLeft / (1000 * 60)) % 60)).padStart(2);
-  const second = String(Math.floor((timeLeft / 1000) % 60)).padStart(2, "0");
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => prev - INTERVAL);
-    }, INTERVAL);
-
-    if (timeLeft <= 0) {
-      clearInterval(timer);
-      alert("다시하세요");
-    }
-
-    return () => clearInterval(timer);
-  }, [timeLeft]);
-
+const AuthTimer = ({ formattedMin, formattedSec }: any) => {
   return (
     <div className="inline-block mb-[7px] text-base text-[#00D179] leading-[22px]">
-      {minutes}분 {second}초
+      {formattedMin}분 {formattedSec}초
     </div>
   );
 };

--- a/src/shared/hook/useAuthTimer.ts
+++ b/src/shared/hook/useAuthTimer.ts
@@ -9,8 +9,13 @@ const useAuthTimer = (initialTime: number) => {
   const formattedMin = Math.floor(time / 60);
   const formattedSec = time % 60;
 
+  let getVerificationNumber: number;
+
   const startTimer = () => {
     setIsRunning(true);
+
+    // TODO: 서버에서 인증번호 받아오는 로직 추가
+    getVerificationNumber = 123456;
   };
 
   const stopTimer = () => {
@@ -37,12 +42,9 @@ const useAuthTimer = (initialTime: number) => {
     }
   }, [isRunning, time]);
 
-  // TODO: 서버에서 인증번호 받아오는 로직으로 수정
-  const verificationNumber = 123456;
-
   // 인증 성공 여부 확인
   const checkValidationNumber = (authNumber: string) => {
-    if (verificationNumber.toString() === authNumber) {
+    if (getVerificationNumber.toString() === authNumber) {
       return true;
     }
     return false;

--- a/src/shared/hook/useAuthTimer.ts
+++ b/src/shared/hook/useAuthTimer.ts
@@ -1,6 +1,8 @@
 // 인증번호 타이머 hook
 import { useState, useEffect } from "react";
 
+let getVerificationNumber: number;
+
 const useAuthTimer = (initialTime: number) => {
   const [time, setTime] = useState(initialTime);
   const [isRunning, setIsRunning] = useState(false);
@@ -8,8 +10,6 @@ const useAuthTimer = (initialTime: number) => {
 
   const formattedMin = Math.floor(time / 60);
   const formattedSec = time % 60;
-
-  let getVerificationNumber: number;
 
   const startTimer = () => {
     setIsRunning(true);
@@ -44,7 +44,7 @@ const useAuthTimer = (initialTime: number) => {
 
   // 인증 성공 여부 확인
   const checkValidationNumber = (authNumber: string) => {
-    if (getVerificationNumber.toString() === authNumber) {
+    if (getVerificationNumber?.toString() === authNumber) {
       return true;
     }
     return false;

--- a/src/shared/hook/useAuthTimer.ts
+++ b/src/shared/hook/useAuthTimer.ts
@@ -1,0 +1,64 @@
+// 인증번호 타이머 hook
+import { useState, useEffect } from "react";
+
+const useAuthTimer = (initialTime: number) => {
+  const [time, setTime] = useState(initialTime);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isExpired, setIsExpired] = useState(false);
+
+  const formattedMin = Math.floor(time / 60);
+  const formattedSec = time % 60;
+
+  const startTimer = () => {
+    setIsRunning(true);
+  };
+
+  const stopTimer = () => {
+    setIsRunning(false);
+  };
+
+  // 재시작 함수
+  const resetTimer = (newTime = initialTime) => {
+    setIsRunning(false);
+    setIsExpired(false);
+    setTime(newTime);
+    startTimer();
+  };
+
+  useEffect(() => {
+    if (isRunning && time > 0) {
+      const intervalId = setInterval(() => {
+        setTime((prevTime) => prevTime - 1);
+      }, 1000);
+
+      return () => clearInterval(intervalId);
+    } else if (time <= 0) {
+      setIsExpired(true);
+    }
+  }, [isRunning, time]);
+
+  // TODO: 서버에서 인증번호 받아오는 로직으로 수정
+  const verificationNumber = 123456;
+
+  // 인증 성공 여부 확인
+  const checkValidationNumber = (authNumber: string) => {
+    if (verificationNumber.toString() === authNumber) {
+      return true;
+    }
+    return false;
+  };
+
+  return {
+    time,
+    formattedMin,
+    formattedSec,
+    isRunning,
+    startTimer,
+    stopTimer,
+    resetTimer,
+    isExpired,
+    checkValidationNumber,
+  };
+};
+
+export default useAuthTimer;

--- a/src/signup/AccountInfo.tsx
+++ b/src/signup/AccountInfo.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import React, { useEffect, useState } from "react";
 import { useSetRecoilState } from "recoil";
 import { signupPageState } from "@shared/recoil/signup";
+import { checkPhoneValidation } from "@shared/utils";
 import Button from "./Button";
 import CheckAuth from "./CheckAuth";
 import Input from "./Input";
@@ -41,6 +42,17 @@ const AccountInfo = () => {
       ...prevFormData,
       [name]: { ...prevFormData[name as FormKey], value },
     }));
+  };
+
+  const handleAuthClick = () => {
+    if (checkPhoneValidation(formData.phone.value)) {
+      setIsDoneInput(true);
+      alert(
+        "인증번호 발송 요청이 완료되었습니다.\n인증번호가 오지 않는 경우, 입력한 이름/휴대폰번호를 확인 후 다시 요청해주세요.",
+      ); // TODO: 아임포트 API와 연결하여 휴대폰 인증 로직
+    } else {
+      alert("휴대폰 번호를 정확히 입력해주세요!");
+    }
   };
 
   const handleFormSubmit = () => {
@@ -119,12 +131,7 @@ const AccountInfo = () => {
             <Button
               label="인증하기"
               disabled={isDoneInput}
-              onClick={() => {
-                setIsDoneInput(true);
-                alert(
-                  "인증번호 발송 요청이 완료되었습니다.\n인증번호가 오지 않는 경우, 입력한 이름/휴대폰번호를 확인 후 다시 요청해주세요.",
-                ); // TODO: 아임포트 API와 연결하여 휴대폰 인증 로직
-              }}
+              onClick={handleAuthClick}
               buttonStyle={`w-[119px] h-[48px] ml-1  ${
                 isDoneInput ? "bg-zinc-400" : "bg-emerald-500"
               }`}

--- a/src/signup/AuthErrorMessage.tsx
+++ b/src/signup/AuthErrorMessage.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useState } from "react";
-import { clearTimeout, setTimeout } from "timers";
+// 인증번호 에러 메시지
 
-const AuthErrorMessage = () => {
-  const [isExpired, setIsExpired] = useState(false);
+interface AuthErrorMessageProps {
+  isExpired: boolean;
+}
 
-  useEffect(() => {
-    setIsExpired(false);
-    const timer = setTimeout(() => {
-      setIsExpired(true);
-    }, 180000);
-
-    return () => clearTimeout(timer);
-  }, []);
-
+const AuthErrorMessage = ({ isExpired }: AuthErrorMessageProps) => {
   return (
     <>
       {isExpired ? (

--- a/src/signup/CheckAuth.tsx
+++ b/src/signup/CheckAuth.tsx
@@ -1,6 +1,7 @@
 // 인증번호 입력 컴포넌트
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AuthTimer } from "@shared/components";
+import useAuthTimer from "@shared/hook/useAuthTimer";
 import { checkAuthNumValidation } from "@shared/utils";
 import AuthErrorMessage from "./AuthErrorMessage";
 import Button from "./Button";
@@ -12,13 +13,46 @@ interface CheckAuthProps {
 
 const CheckAuth = ({ isDoneInput }: CheckAuthProps) => {
   const [authNum, setAuthNum] = useState("");
+  const [isCodeCorrect, setIsCodeCorrect] = useState(false); // 인증 성공 여부
 
-  // TODO: 인증번호 인증 로직 구현
+  const {
+    formattedMin,
+    formattedSec,
+    startTimer,
+    stopTimer,
+    resetTimer,
+    isExpired,
+    checkValidationNumber,
+  } = useAuthTimer(180);
+
+  useEffect(() => {
+    if (isDoneInput) {
+      startTimer();
+    }
+  }, [isDoneInput]);
+
+  // 사용자의 인증 번호가 바뀔 때 마다 인증 성공 여부 확인
+  useEffect(() => {
+    if (checkAuthNumValidation(authNum)) {
+      if (checkValidationNumber(authNum)) {
+        setIsCodeCorrect(true);
+        stopTimer();
+      }
+    } else {
+      setIsCodeCorrect(false);
+    }
+  }, [authNum]);
+
   const handleAuthNum = (value: string) => {
     setAuthNum(value);
   };
 
-  const isAuthNumValidate = checkAuthNumValidation(authNum);
+  const onClickReset = () => {
+    alert(
+      "인증번호 발송 요청이 완료되었습니다.\n인증번호가 오지 않는 경우, 입력한 이름/휴대폰번호를 확인 후 다시 요청해주세요.",
+    );
+    resetTimer();
+  };
 
   return (
     <div className="flex flex-col">
@@ -37,28 +71,27 @@ const CheckAuth = ({ isDoneInput }: CheckAuthProps) => {
         </div>
         <Button
           label="재발송"
-          onClick={() => {
-            alert(
-              "인증번호 발송 요청이 완료되었습니다.\n인증번호가 오지 않는 경우, 입력한 이름/휴대폰번호를 확인 후 다시 요청해주세요.",
-            ); // TODO: 아임포트 API와 연결하여 휴대폰 인증 로직
-          }}
+          onClick={onClickReset}
           buttonStyle="w-[119px] h-[48px] bg-amber-300 ml-1"
         />
 
         {/* 인증하기 버튼 누를 시 나오는 Timer */}
         {isDoneInput && (
           <div className="absolute -top-2 right-32">
-            <AuthTimer />
+            <AuthTimer
+              formattedMin={formattedMin}
+              formattedSec={formattedSec}
+            />
           </div>
         )}
       </div>
 
-      {/* TODO: 인증번호 인증 로직 구현 (현재는 6자리면 에러메시지 안나옴) */}
+      {/* TODO: 인증번호 인증 로직 구현 (현재 인증번호는 123456이면 인증 성공) */}
       {isDoneInput ? (
-        isAuthNumValidate ? (
-          <div className="h-[16px] invisible mt-[5px] mb-[12px]" />
+        !isExpired && isCodeCorrect ? (
+          <div className="text-[#00D179]  mt-[5px] mb-[12px]">인증 성공!</div>
         ) : (
-          <AuthErrorMessage />
+          <AuthErrorMessage isExpired={isExpired} />
         )
       ) : (
         <div className="h-[16px] invisible mt-[5px] mb-[12px]" />


### PR DESCRIPTION
## 변경사항
- useAuthTimer hook 추가

## 테스트
- http://localhost:3000/signup 내부 2번째 페이지

## TODO
- 서버에서 전송한 인증번호를 받아 사용자가 입력한 인증번호와 비교하는 로직 추가 (현재는 인증번호 발급 로직이 없어 임시로 123456 이면 인증성공으로 구현)
- feat/signup-page 브랜치로 pr 올림. 진욱님과 로직 비교 후, merge 예정